### PR TITLE
Fixed a typo in the stable_marriages.py

### DIFF
--- a/chapters/computational_mathematics/decision_problems/stable_marriage/code/python/stable_marriage.py
+++ b/chapters/computational_mathematics/decision_problems/stable_marriage/code/python/stable_marriage.py
@@ -13,7 +13,7 @@ def main():
         num_pairs = 5
 
     # There are only 26 possible names
-    if num_paris > 13:
+    if num_pairs > 13:
         print('You can\' have more than 13 pairs.')
         return
 


### PR DESCRIPTION
When merged, this Pull Request fixes a typo in the Python 3 implementation of the stable marriages problem. Thanks to @Gathros for spotting this one.