### PR TITLE
Create a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,80 @@
+root = true
+
+# This file
+[.editorconfig]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Pretty much everything should trim whitespace and have a final EOL
+[*.{c,clj,cpp,cs,css,elm,go,hs,html,jl,js,md,py,rs}]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# C
+[*.c]
+indent_style = space
+indent_size = 4
+
+# Clojure
+[*.clj]
+indent_style = space
+indent_size = 2
+
+# C++
+[*.cpp]
+indent_style = space
+indent_size = 2
+
+# C#
+[*.cs]
+indent_style = space
+indent_size = 4
+
+# CSS
+[*.css]
+indent_style = space
+indent_size = 2
+
+# Elm
+[*.elm]
+indent_style = space
+indent_size = 2
+
+# Go
+[*.go]
+indent_style = tab
+
+# Haskell
+[*.hs]
+indent_style = space
+indent_size = 2
+
+# HTML
+[*.html]
+indent_style = space
+indent_size = 2
+
+# Julia
+[*.jl]
+indent_style = space
+indent_size = 4
+
+# JavaScript
+[*.js]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+indent_style = space
+indent_size = 2
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Rust
+[*.rs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
When merged, this pull request will add a configuration file for EditorConfig. EditorConfig is a collection of plugins that use the same configuration file. Plugins are available for many common text editors. [Go to editorconfig.org for more information and plugin downloads.](http://editorconfig.org/)

The goal of adding such a configuration to the AAA is to make it easier for contributors to write consistently styled code throughout the entire project. The file will mainly contain two options for each language: "indent_style" and "indent_size" for spaces or "tab_width" for tabs.

This Pull Request exists as a place for discussion until we can agree on indentation styles for every language. Feel free to propose more languages that are not currently used in the AAA but could be in the future!

Here is a list of languages that will be included in the file.

 - [x] C
 - [x] C++
 -  - [x] Pull request #61 (switch over to clang-format style)
 - [x] Clojure
 - [X] C#
 - [X] CSS
 - [X] Elm
 - [X] Go
 - [X] Haskell
 - [X] HTML
 - [X] Julia
 - [X] JavaScript
 - [x] Markdown
 - [X] Python
 - [X] Rust