### PR TITLE
Add new .gitignore created with gitignore.io (arguments: Linux, macOS, Windows, GitBook).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-# Created by https://www.gitignore.io/api/gitbook
+# Created by https://www.gitignore.io/api/linux,macos,windows,gitbook
 
 ### GitBook ###
 # Node rules:
@@ -19,8 +19,68 @@ _book
 *.mobi
 *.pdf
 
-# Other
-*.xcf
+### Linux ###
+*~
 
-# End of https://www.gitignore.io/api/gitbook
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
 
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+# End of https://www.gitignore.io/api/linux,macos,windows,gitbook


### PR DESCRIPTION
The updated `.gitignore` catches the files created by various operating systems.

Should we include common editors like `VSCode`, `Vim` and so on in the `.gitignore` as well?